### PR TITLE
feat(merchants): add Uberspace.de's network ID

### DIFF
--- a/lib/yellow_pages/merchants.yaml
+++ b/lib/yellow_pages/merchants.yaml
@@ -345,3 +345,5 @@
   name: "Green Mountain Transit"
 - network_ids: ["47986901"]
   name: "Post Office Counter"
+- network_ids: ["XKPH71LZ3KCA8SQ"]
+  name: "Uberspace"


### PR DESCRIPTION
MID collected via a quick EUR 5 top-up to @recaptime-dev's asteroid on Uberspace from [HCB](https://hcb.hackclub.com/hcb/gnHrkn9). Edited via good ol' GitHub web editor (might test it on Codespaces later).

_*Context*: [Slack dev thread](https://hackclub.slack.com/archives/C068U0JMV19/p1737365418015709), [wishing well](https://hackclub.slack.com/archives/C07443MC9UP/p1736641226399999)_