### PR TITLE
chore(merchants): add @cloudflare's Visa merchant ID

### DIFF
--- a/lib/yellow_pages/merchants.yaml
+++ b/lib/yellow_pages/merchants.yaml
@@ -350,3 +350,5 @@
   name: "Uberspace"
 - network_ids: ["31431585"]
   name: "Royal Mail"
+- network_ids: ["H6LVNPMMWPPT9VW"]
+  name: "Cloudflare"


### PR DESCRIPTION
Technically provided via https://hcb.hackclub.com/grants/DZIj2Y (HCB staff + High Seas team only), but I have to explicitly add them to the merchants.yml file for future use.

See also [this thread](https://hackclub.slack.com/archives/C07PZNMBPBN/p1738466213290069) in `#high-seas-help` Slack channel for context.