### PR TITLE
chore(merchants): add Shopee and Lazada PH MIDs

### DIFF
--- a/lib/yellow_pages/merchants.yaml
+++ b/lib/yellow_pages/merchants.yaml
@@ -382,3 +382,7 @@
   name: "Flipkart"
 - network_ids: ["N1VWJHWU8ER01FU"]
   name: "Framework"
+- network_ids: ["104276479"]
+  name: "Shopee"
+- network_ids: ["9182087924"]
+  name: "Lazada"


### PR DESCRIPTION
Source (they're card linking operations, nothing purchased yet):
- https://hcb.hackclub.com/stripe_cards/XKh8Z5
- https://hcb.hackclub.com/hcb/EyHw9Wa

I may need help getting MIDs for other storefronts outside PH in Slack soon.

Additional context: https://hackclub.slack.com/archives/CN523HLKW/p1755870336857859